### PR TITLE
feat: 회원가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	// web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// security
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/example/fastcoupon/config/JpaAuditingConfig.java
+++ b/src/main/java/com/example/fastcoupon/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.example.fastcoupon.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/example/fastcoupon/config/SecurityConfig.java
+++ b/src/main/java/com/example/fastcoupon/config/SecurityConfig.java
@@ -1,0 +1,41 @@
+package com.example.fastcoupon.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .cors(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/signup", "/api/login").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+                )
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/fastcoupon/controller/UserController.java
+++ b/src/main/java/com/example/fastcoupon/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.example.fastcoupon.controller;
+
+import com.example.fastcoupon.dto.user.SignupRequestDto;
+import com.example.fastcoupon.dto.user.UserResponseDto;
+import com.example.fastcoupon.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<UserResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto) {
+        userService.signup(requestDto);
+        return ResponseEntity.ok(new UserResponseDto(requestDto.getName(), "회원가입 성공"));
+    }
+
+}

--- a/src/main/java/com/example/fastcoupon/dto/common/BasicResponseDto.java
+++ b/src/main/java/com/example/fastcoupon/dto/common/BasicResponseDto.java
@@ -1,0 +1,36 @@
+package com.example.fastcoupon.dto.common;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class BasicResponseDto {
+
+    private int statusCode;
+    private String msg;
+    private List<String> errorMessages;
+
+    public BasicResponseDto(int statusCode, String msg) {
+        this.statusCode = statusCode;
+        this.msg = msg;
+    }
+
+    public BasicResponseDto(int statusCode, String msg, List<String> errorMessages) {
+        this.statusCode = statusCode;
+        this.msg = msg;
+        this.errorMessages = errorMessages;
+    }
+
+    public static BasicResponseDto addSuccess(String msg) {
+        return new BasicResponseDto(HttpStatus.OK.value(), msg);
+    }
+
+    public static BasicResponseDto addBadRequest(String msg, List<String> errorMessages) {
+        return new BasicResponseDto(HttpStatus.BAD_REQUEST.value(), msg, errorMessages);
+    }
+
+}

--- a/src/main/java/com/example/fastcoupon/dto/common/ErrorResponseDto.java
+++ b/src/main/java/com/example/fastcoupon/dto/common/ErrorResponseDto.java
@@ -1,0 +1,24 @@
+package com.example.fastcoupon.dto.common;
+
+import com.example.fastcoupon.enums.ExceptionEnum;
+import lombok.Getter;
+
+@Getter
+public class ErrorResponseDto {
+
+    private int status;
+    private String type;
+    private String msg;
+
+    public ErrorResponseDto(int status, String type, String msg) {
+        this.status = status;
+        this.type = type;
+        this.msg = msg;
+    }
+
+    public ErrorResponseDto(ExceptionEnum exceptionEnum) {
+        this.status = exceptionEnum.getStatus();
+        this.type = exceptionEnum.getType();
+        this.msg = exceptionEnum.getMsg();
+    }
+}

--- a/src/main/java/com/example/fastcoupon/dto/user/SignupRequestDto.java
+++ b/src/main/java/com/example/fastcoupon/dto/user/SignupRequestDto.java
@@ -1,0 +1,29 @@
+package com.example.fastcoupon.dto.user;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupRequestDto {
+
+    @Pattern(regexp = "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "유효한 이메일 주소를 입력해주세요.")
+    @NotBlank(message = "E-mail을 입력해주세요.")
+    private String email;
+
+    @Size(min = 8, max = 15, message = "비밀번호는 최소 8자에서 15자 사이로만 가능합니다.")
+    @Pattern(regexp = "(?=.*[a-zA-Z])(?=.*[0-9])(?=.*\\p{Punct}).+$", message = "비밀번호는 대소문자, 숫자, 특수문자를 포함해야됩니다.")
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+    @NotBlank(message = "성함을 입력해주세요.")
+    private String name;
+
+    @NotBlank(message = "전화번호를 입력해주세요.")
+    private String tel;
+
+
+}

--- a/src/main/java/com/example/fastcoupon/dto/user/UserResponseDto.java
+++ b/src/main/java/com/example/fastcoupon/dto/user/UserResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.fastcoupon.dto.user;
+
+import lombok.Getter;
+
+@Getter
+public class UserResponseDto {
+
+    private String name;
+    private String msg;
+
+    public UserResponseDto(String name, String msg) {
+        this.name = name;
+        this.msg = msg;
+    }
+
+}
+

--- a/src/main/java/com/example/fastcoupon/entity/User.java
+++ b/src/main/java/com/example/fastcoupon/entity/User.java
@@ -1,0 +1,45 @@
+package com.example.fastcoupon.entity;
+
+import com.example.fastcoupon.entity.base.Timestamped;
+import com.example.fastcoupon.enums.UserRoleEnum;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends Timestamped {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String tel;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserRoleEnum role;
+
+    @Builder
+    public User(String name, String email, String password, String tel, UserRoleEnum role) {
+        this.name = name;
+        this.email = email;
+        this.password = password;
+        this.tel = tel;
+        this.role = role;
+    }
+
+}

--- a/src/main/java/com/example/fastcoupon/entity/base/Timestamped.java
+++ b/src/main/java/com/example/fastcoupon/entity/base/Timestamped.java
@@ -1,0 +1,19 @@
+package com.example.fastcoupon.entity.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class Timestamped {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/fastcoupon/enums/ExceptionEnum.java
+++ b/src/main/java/com/example/fastcoupon/enums/ExceptionEnum.java
@@ -1,0 +1,19 @@
+package com.example.fastcoupon.enums;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ExceptionEnum {
+    EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST.value(),"USER", "중복된 이메일입니다.");
+
+    private final int status;
+    private final String type;
+    private final String msg;
+
+    ExceptionEnum(int status, String type, String msg) {
+        this.status = status;
+        this.type = type;
+        this.msg = msg;
+    }
+}

--- a/src/main/java/com/example/fastcoupon/enums/UserRoleEnum.java
+++ b/src/main/java/com/example/fastcoupon/enums/UserRoleEnum.java
@@ -1,0 +1,20 @@
+package com.example.fastcoupon.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum UserRoleEnum {
+    USER(Authority.USER),
+    ADMIN(Authority.ADMIN);
+
+    private final String authority;
+
+    UserRoleEnum(String authority) {
+        this.authority = authority;
+    }
+
+    private static class Authority {
+        private static final String USER = "ROLE_USER";
+        private static final String ADMIN = "ROLE_ADMIN";
+    }
+}

--- a/src/main/java/com/example/fastcoupon/exception/ErrorException.java
+++ b/src/main/java/com/example/fastcoupon/exception/ErrorException.java
@@ -1,0 +1,15 @@
+package com.example.fastcoupon.exception;
+
+import com.example.fastcoupon.enums.ExceptionEnum;
+import lombok.Getter;
+
+@Getter
+public class ErrorException extends RuntimeException {
+
+    private final ExceptionEnum exceptionEnum;
+
+    public ErrorException(ExceptionEnum exceptionEnum) {
+        super(exceptionEnum.getMsg());
+        this.exceptionEnum = exceptionEnum;
+    }
+}

--- a/src/main/java/com/example/fastcoupon/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/fastcoupon/exception/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.example.fastcoupon.exception;
+
+import com.example.fastcoupon.dto.common.BasicResponseDto;
+import com.example.fastcoupon.dto.common.ErrorResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler({MethodArgumentNotValidException.class, HttpMessageNotReadableException.class})
+    public ResponseEntity<BasicResponseDto> signValidException(MethodArgumentNotValidException exception) {
+        BindingResult bindingResult = exception.getBindingResult();
+
+        List<String> errors = bindingResult.getFieldErrors().stream()
+                .map(error -> String.format("[%s] %s", error.getField(), error.getDefaultMessage()))
+                .toList();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST.value()).body(BasicResponseDto.addBadRequest("유효성 검증에 실패했습니다.", errors));
+    }
+
+    @ExceptionHandler(ErrorException.class)
+    public ResponseEntity<ErrorResponseDto> handleErrorException(ErrorException e) {
+        log.warn("[{} 예외]: {}", e.getExceptionEnum().getMsg());
+
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(
+                e.getExceptionEnum().getStatus(), e.getExceptionEnum().getType(), e.getExceptionEnum().getMsg()
+        );
+        return ResponseEntity.status(e.getExceptionEnum().getStatus()).body(errorResponseDto);
+    }
+
+
+}

--- a/src/main/java/com/example/fastcoupon/repository/UserRepository.java
+++ b/src/main/java/com/example/fastcoupon/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.example.fastcoupon.repository;
+
+import com.example.fastcoupon.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+}

--- a/src/main/java/com/example/fastcoupon/service/UserService.java
+++ b/src/main/java/com/example/fastcoupon/service/UserService.java
@@ -1,0 +1,45 @@
+package com.example.fastcoupon.service;
+
+import com.example.fastcoupon.dto.user.SignupRequestDto;
+import com.example.fastcoupon.entity.User;
+import com.example.fastcoupon.enums.ExceptionEnum;
+import com.example.fastcoupon.enums.UserRoleEnum;
+import com.example.fastcoupon.exception.ErrorException;
+import com.example.fastcoupon.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void signup(SignupRequestDto requestDto) {
+        String email = requestDto.getEmail();
+        String password = passwordEncoder.encode(requestDto.getPassword());
+        String name = requestDto.getName();
+        String tel = requestDto.getTel();
+
+        Optional<User> checkEmail = userRepository.findByEmail(email);
+        if (checkEmail.isPresent()) {
+            throw new ErrorException(ExceptionEnum.EMAIL_DUPLICATION);
+        }
+
+        User user = User.builder()
+                .email(email)
+                .password(password)
+                .name(name)
+                .tel(tel)
+                .role(UserRoleEnum.USER)
+                .build();
+        userRepository.save(user);
+    }
+
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%5level) %cyan(%logger) - %magenta(%msg)\n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.example.fastcoupon" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## 💡 작업 개요
- 회원가입 API를 구현
- 세션 기반 인증 방식 사용
- 전역 예외 처리 및 응답 포맷을 통합

## 🔧 변경 사항
- UserController 생성
- UserService 비즈니스 로직 구현
- SignupRequestDto, UserResponseDto 추가
- UserRepository + findByEmail() 메서드 구현
- 비밀번호 암호화 (BCryptPasswordEncoder 사용)

## ⚠ 전역 예외 처리 및 응답 포맷
- GlobalExceptionHandler: 유효성 검증 및 커스텀 예외 처리 추가
- ExceptionEnum: 예외 타입/메시지/상태 코드 정의
- ErrorResponseDto: 에러 응답 포맷 통일
- ErrorException: 커스텀 예외 처리용 RuntimeException
- BasicResponseDto: 성공/실패 기본 응답 DTO 설계

## ✅ 테스트 결과
- Postman으로 회원가입 성공 확인
- 유효성 검사 실패 시 400 응답 확인