### PR TITLE
feat(user): 로그인 기능 구현 (세션 기반, AOP 적용)

### DIFF
--- a/src/main/java/com/example/fastcoupon/aop/LoginSessionAspect.java
+++ b/src/main/java/com/example/fastcoupon/aop/LoginSessionAspect.java
@@ -1,0 +1,41 @@
+package com.example.fastcoupon.aop;
+
+import com.example.fastcoupon.dto.user.UserResponseDto;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class LoginSessionAspect {
+
+    @Around("@annotation(com.example.fastcoupon.aop.LoginSessionInject)")
+    public Object injectSession(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object result = joinPoint.proceed();
+
+        ServletRequestAttributes attributes =
+                (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+        HttpServletRequest request = attributes.getRequest();
+
+        if (result instanceof ResponseEntity<?> responseEntity) {
+            Object body = responseEntity.getBody();
+
+            if (body instanceof UserResponseDto dto) {
+                request.getSession().setAttribute("userId", dto.getUserId());
+                log.info("✅ 세션 저장 userId = {}", dto.getUserId());
+            }
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/com/example/fastcoupon/aop/LoginSessionInject.java
+++ b/src/main/java/com/example/fastcoupon/aop/LoginSessionInject.java
@@ -1,0 +1,9 @@
+package com.example.fastcoupon.aop;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginSessionInject {
+
+}

--- a/src/main/java/com/example/fastcoupon/config/WebMvcConfig.java
+++ b/src/main/java/com/example/fastcoupon/config/WebMvcConfig.java
@@ -1,0 +1,19 @@
+package com.example.fastcoupon.config;
+
+import com.example.fastcoupon.logging.LoggingInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final LoggingInterceptor loggingInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loggingInterceptor).addPathPatterns("/**");
+    }
+}

--- a/src/main/java/com/example/fastcoupon/controller/UserController.java
+++ b/src/main/java/com/example/fastcoupon/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.example.fastcoupon.controller;
 
+import com.example.fastcoupon.aop.LoginSessionInject;
+import com.example.fastcoupon.dto.LoginRequestDto;
 import com.example.fastcoupon.dto.user.SignupRequestDto;
 import com.example.fastcoupon.dto.user.UserResponseDto;
 import com.example.fastcoupon.service.UserService;
@@ -20,8 +22,13 @@ public class UserController {
 
     @PostMapping("/signup")
     public ResponseEntity<UserResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto) {
-        userService.signup(requestDto);
-        return ResponseEntity.ok(new UserResponseDto(requestDto.getName(), "회원가입 성공"));
+        return ResponseEntity.ok( userService.signup(requestDto));
+    }
+
+    @LoginSessionInject
+    @PostMapping("/login")
+    public ResponseEntity<UserResponseDto> login(@Valid @RequestBody LoginRequestDto requestDto) {
+        return ResponseEntity.ok(userService.login(requestDto));
     }
 
 }

--- a/src/main/java/com/example/fastcoupon/dto/LoginRequestDto.java
+++ b/src/main/java/com/example/fastcoupon/dto/LoginRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.fastcoupon.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequestDto {
+
+    @NotBlank(message = "E-mail을 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+}

--- a/src/main/java/com/example/fastcoupon/dto/user/UserResponseDto.java
+++ b/src/main/java/com/example/fastcoupon/dto/user/UserResponseDto.java
@@ -5,13 +5,14 @@ import lombok.Getter;
 @Getter
 public class UserResponseDto {
 
+    private Long userId;
     private String name;
     private String msg;
 
-    public UserResponseDto(String name, String msg) {
+    public UserResponseDto(Long userId, String name, String msg) {
+        this.userId = userId;
         this.name = name;
         this.msg = msg;
     }
-
 }
 

--- a/src/main/java/com/example/fastcoupon/enums/ExceptionEnum.java
+++ b/src/main/java/com/example/fastcoupon/enums/ExceptionEnum.java
@@ -5,7 +5,9 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ExceptionEnum {
-    EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST.value(),"USER", "중복된 이메일입니다.");
+    EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST.value(),"USER", "중복된 이메일입니다."),
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "USER", "사용자를 찾을 수 없습니다."),
+    WRONG_PASSWORD(HttpStatus.BAD_REQUEST.value(), "USER", "비밀번호가 일치하지 않습니다.");
 
     private final int status;
     private final String type;

--- a/src/main/java/com/example/fastcoupon/logging/CachingRequestFilter.java
+++ b/src/main/java/com/example/fastcoupon/logging/CachingRequestFilter.java
@@ -1,0 +1,71 @@
+package com.example.fastcoupon.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class CachingRequestFilter extends OncePerRequestFilter {
+
+    private static final String TRACE_ID = "traceId";
+    private static final String USER_ID = "userId";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+
+        String traceId = UUID.randomUUID().toString();
+        MDC.put(TRACE_ID, traceId);
+        requestWrapper.setAttribute(TRACE_ID, traceId);
+
+        try {
+            filterChain.doFilter(requestWrapper, responseWrapper);
+            logRequestBody(requestWrapper, traceId);
+        } finally {
+            responseWrapper.copyBodyToResponse();
+            MDC.clear();
+        }
+    }
+
+    private void logRequestBody(ContentCachingRequestWrapper request, String traceId) {
+        MDC.put(TRACE_ID, traceId);
+
+        String contentType = request.getContentType();
+        String method = request.getMethod();
+        String uri = request.getRequestURI();
+
+        if (request.getContentLength() == 0) {
+            log.info("✅ RequestBody: [{}] empty body", traceId);
+            return;
+        }
+
+        if (contentType != null && contentType.contains("application/json")) {
+            String body = new String(request.getContentAsByteArray(), StandardCharsets.UTF_8);
+            String maskedBody = maskSensitiveFields(body);
+            log.info("✅ RequestBody: [{}] [{} {}] {}", traceId , method, uri, maskedBody);
+        } else {
+            log.info("✅ RequestBody: [{}] Unsupported or missing content-type: {}", traceId, contentType);
+        }
+    }
+
+    private String maskSensitiveFields(String body) {
+        return body.replaceAll("(?i)(\"password\"\\s*:\\s*\")[^\"]*(\")", "$1***$2");
+    }
+
+}

--- a/src/main/java/com/example/fastcoupon/logging/LoggingInterceptor.java
+++ b/src/main/java/com/example/fastcoupon/logging/LoggingInterceptor.java
@@ -1,0 +1,38 @@
+package com.example.fastcoupon.logging;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+public class LoggingInterceptor implements HandlerInterceptor {
+
+    private static final String TRACE_ID = "traceId";
+
+    @Override
+    public void afterCompletion(HttpServletRequest request,
+                                HttpServletResponse response,
+                                Object handler,
+                                Exception ex) {
+
+        String traceId = MDC.get(TRACE_ID);
+        String method = request.getMethod();
+        String uri = request.getRequestURI();
+
+        if (response instanceof ContentCachingResponseWrapper wrapper) {
+            String responseBody = new String(wrapper.getContentAsByteArray(), StandardCharsets.UTF_8);
+            log.info("✅ ResponseBody: [{}] [{} {}] {} {}\nBody: {}", traceId, method, uri, response.getStatus(), response.getContentType(), responseBody);
+        } else {
+            log.warn("Response body unavailable — wrapper missing");
+        }
+
+        MDC.clear();
+    }
+}

--- a/src/main/java/com/example/fastcoupon/service/UserService.java
+++ b/src/main/java/com/example/fastcoupon/service/UserService.java
@@ -1,6 +1,8 @@
 package com.example.fastcoupon.service;
 
+import com.example.fastcoupon.dto.LoginRequestDto;
 import com.example.fastcoupon.dto.user.SignupRequestDto;
+import com.example.fastcoupon.dto.user.UserResponseDto;
 import com.example.fastcoupon.entity.User;
 import com.example.fastcoupon.enums.ExceptionEnum;
 import com.example.fastcoupon.enums.UserRoleEnum;
@@ -21,7 +23,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public void signup(SignupRequestDto requestDto) {
+    public UserResponseDto signup(SignupRequestDto requestDto) {
         String email = requestDto.getEmail();
         String password = passwordEncoder.encode(requestDto.getPassword());
         String name = requestDto.getName();
@@ -40,6 +42,23 @@ public class UserService {
                 .role(UserRoleEnum.USER)
                 .build();
         userRepository.save(user);
+        return new UserResponseDto(user.getId(), user.getName(), "회원가입 성공");
+    }
+
+    @Transactional
+    public UserResponseDto login(LoginRequestDto requestDto) {
+        String email = requestDto.getEmail();
+        String password = requestDto.getPassword();
+
+        User user = userRepository.findByEmail(email).orElseThrow(
+                () -> new ErrorException(ExceptionEnum.USER_NOT_FOUND)
+        );
+
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new ErrorException(ExceptionEnum.WRONG_PASSWORD);
+        }
+
+        return new UserResponseDto(user.getId(), user.getName(), "로그인 성공");
     }
 
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%5level) %cyan(%logger) - %magenta(%msg)\n"/>
+    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%5level) %cyan(%logger) - %magenta(%msg) [traceId=%X{traceId}]\n"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
## 💡주요 내용
- 로그인 API (`POST /api/login`) 구현
- LoginRequestDto 추가 및 UserResponseDto 수정
- UserService에 로그인 로직 구현 (비밀번호 검증, 예외 처리 포함)
- ExceptionEnum에 로그인 관련 예외 항목 추가
- 세션 저장 AOP 로직 (@LoginSessionInject, LoginSessionAspect) 적용
- Controller는 Servlet 의존 없이 응답만 리턴