### PR TITLE
feat(coupon): 쿠폰 사용 및 만료 처리 기능 추가

### DIFF
--- a/src/main/java/com/example/fastcoupon/FastcouponApplication.java
+++ b/src/main/java/com/example/fastcoupon/FastcouponApplication.java
@@ -2,8 +2,10 @@ package com.example.fastcoupon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class FastcouponApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/fastcoupon/controller/CouponController.java
+++ b/src/main/java/com/example/fastcoupon/controller/CouponController.java
@@ -3,6 +3,7 @@ package com.example.fastcoupon.controller;
 import com.example.fastcoupon.dto.common.BasicResponseDto;
 import com.example.fastcoupon.redis.RedisCouponService;
 import com.example.fastcoupon.security.UserDetailsImpl;
+import com.example.fastcoupon.service.CouponUseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CouponController {
 
     private final RedisCouponService redisCouponService;
+    private final CouponUseService couponUseService;
 
     @PostMapping("/{couponId}/issue")
     public ResponseEntity<BasicResponseDto> issueCoupon(
@@ -26,4 +28,15 @@ public class CouponController {
         redisCouponService.pushQueue(couponId, userDetails.getUser().getId());
         return ResponseEntity.ok(BasicResponseDto.addSuccess("쿠폰 발급 성공"));
     }
+
+    @PostMapping("/{couponId}/issued/{couponIssueId}/use")
+    public ResponseEntity<BasicResponseDto> useCoupon(
+            @PathVariable("couponId") Long couponId,
+            @PathVariable("couponIssueId") Long couponIssueId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        couponUseService.useCoupon(couponId, couponIssueId, userDetails.getUser().getId());
+        return ResponseEntity.ok(BasicResponseDto.addSuccess("쿠폰 사용 완료"));
+    }
+
 }

--- a/src/main/java/com/example/fastcoupon/entity/CouponIssue.java
+++ b/src/main/java/com/example/fastcoupon/entity/CouponIssue.java
@@ -2,8 +2,6 @@ package com.example.fastcoupon.entity;
 
 import com.example.fastcoupon.entity.base.Timestamped;
 import com.example.fastcoupon.enums.CouponStatusEnum;
-import com.example.fastcoupon.enums.ExceptionEnum;
-import com.example.fastcoupon.exception.ErrorException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -49,13 +47,16 @@ public class CouponIssue extends Timestamped {
         this.userId = userId;
     }
 
-    // 쿠폰 사용 처리
-    public void use() {
-        if (this.used) {
-            throw new ErrorException(ExceptionEnum.COUPON_ALREADY_USED);
-        }
-        this.used = true;
-        this.usedAt = LocalDateTime.now();
-        this.status = CouponStatusEnum.USED;
+    public void updateUsed(boolean used) {
+        this.used = used;
     }
+
+    public void updateUsedAt(LocalDateTime usedAt) {
+        this.usedAt = usedAt;
+    }
+
+    public void updateStatus(CouponStatusEnum status) {
+        this.status = status;
+    }
+
 }

--- a/src/main/java/com/example/fastcoupon/enums/ExceptionEnum.java
+++ b/src/main/java/com/example/fastcoupon/enums/ExceptionEnum.java
@@ -8,14 +8,15 @@ public enum ExceptionEnum {
     EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST.value(),"USER", "중복된 이메일입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "USER", "사용자를 찾을 수 없습니다."),
     WRONG_PASSWORD(HttpStatus.BAD_REQUEST.value(), "USER", "비밀번호가 일치하지 않습니다."),
-    NOT_ALLOW(HttpStatus.FORBIDDEN.value(), "권한이 없습니다.", "USER"),
-    COUPON_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 쿠폰이 존재하지 않습니다.", "COUPON"),
-    COUPON_ALREADY_ISSUED(HttpStatus.BAD_REQUEST.value(), "이미 해당 쿠폰을 발급받았습니다.", "COUPON"),
-    COUPON_OUT_OF_STOCK(HttpStatus.BAD_REQUEST.value(), "남은 쿠폰 수량이 없습니다.", "COUPON"),
-    COUPON_ALREADY_USED(HttpStatus.BAD_REQUEST.value(), "이미 사용된 쿠폰입니다.", "COUPON"),
-    LOCK_ACQUISITION_FAILED(HttpStatus.TOO_MANY_REQUESTS.value(), "요청이 몰려 있어 잠시 후 다시 시도해주세요.", "COUPON"),
-    INTERRUPTED_DURING_LOCK(HttpStatus.INTERNAL_SERVER_ERROR.value(), "처리 중 인터럽트가 발생했습니다.", "COUPON"),
-    COUPON_LUA_UNEXPECTED_RESULT(HttpStatus.INTERNAL_SERVER_ERROR.value(), "쿠폰 발급 중 알 수 없는 오류가 발생했습니다.", "COUPON");
+    NOT_ALLOW(HttpStatus.FORBIDDEN.value(), "USER", "권한이 없습니다."),
+    COUPON_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "COUPON", "해당 쿠폰이 존재하지 않습니다."),
+    COUPON_ALREADY_ISSUED(HttpStatus.BAD_REQUEST.value(), "COUPON", "이미 해당 쿠폰을 발급받았습니다."),
+    COUPON_OUT_OF_STOCK(HttpStatus.BAD_REQUEST.value(), "COUPON", "남은 쿠폰 수량이 없습니다."),
+    COUPON_ALREADY_USED(HttpStatus.BAD_REQUEST.value(), "COUPON", "이미 사용된 쿠폰입니다."),
+    LOCK_ACQUISITION_FAILED(HttpStatus.TOO_MANY_REQUESTS.value(), "COUPON", "요청이 몰려 있어 잠시 후 다시 시도해주세요."),
+    INTERRUPTED_DURING_LOCK(HttpStatus.INTERNAL_SERVER_ERROR.value(), "COUPON", "처리 중 인터럽트가 발생했습니다."),
+    COUPON_LUA_UNEXPECTED_RESULT(HttpStatus.INTERNAL_SERVER_ERROR.value(), "COUPON", "쿠폰 발급 중 알 수 없는 오류가 발생했습니다."),
+    COUPON_EXPIRED(HttpStatus.BAD_REQUEST.value(), "COUPON", "만료된 쿠폰은 사용할 수 없습니다.");
 
     private final int status;
     private final String type;

--- a/src/main/java/com/example/fastcoupon/repository/CouponIssueRepository.java
+++ b/src/main/java/com/example/fastcoupon/repository/CouponIssueRepository.java
@@ -1,14 +1,13 @@
 package com.example.fastcoupon.repository;
 
 import com.example.fastcoupon.entity.CouponIssue;
+import com.example.fastcoupon.enums.CouponStatusEnum;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface CouponIssueRepository extends JpaRepository<CouponIssue, Long> {
 
-    Optional<CouponIssue> findByCouponIdAndUserId(Long couponId, Long userId);
-
-    boolean existsByCouponIdAndUserId(Long couponId, Long userId);
+    List<CouponIssue> findAllByCouponIdAndStatus(Long couponId, CouponStatusEnum status);
 
 }

--- a/src/main/java/com/example/fastcoupon/repository/CouponRepository.java
+++ b/src/main/java/com/example/fastcoupon/repository/CouponRepository.java
@@ -3,5 +3,11 @@ package com.example.fastcoupon.repository;
 import com.example.fastcoupon.entity.Coupon;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
+
+    List<Coupon> findAllByExpiredAtBetween(LocalDateTime from, LocalDateTime now);
+
 }

--- a/src/main/java/com/example/fastcoupon/scheduler/CouponExpireScheduler.java
+++ b/src/main/java/com/example/fastcoupon/scheduler/CouponExpireScheduler.java
@@ -1,0 +1,46 @@
+package com.example.fastcoupon.scheduler;
+
+import com.example.fastcoupon.entity.Coupon;
+import com.example.fastcoupon.entity.CouponIssue;
+import com.example.fastcoupon.enums.CouponStatusEnum;
+import com.example.fastcoupon.repository.CouponIssueRepository;
+import com.example.fastcoupon.repository.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponExpireScheduler {
+
+    private final CouponRepository couponRepository;
+    private final CouponIssueRepository couponIssueRepository;
+
+    @Scheduled(cron = "0 0 * * * *")
+//    @Scheduled(cron = "*/5 * * * * *")
+    @Transactional
+    public void markExpiredCoupons() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime oneHourAgo = now.minusHours(1);
+
+        List<Coupon> expiredCoupons = couponRepository.findAllByExpiredAtBetween(oneHourAgo, now);
+
+        for (Coupon coupon : expiredCoupons) {
+            List<CouponIssue> issues = couponIssueRepository.findAllByCouponIdAndStatus(
+                    coupon.getId(), CouponStatusEnum.UNUSED
+            );
+            for (CouponIssue issue : issues) {
+                issue.updateStatus(CouponStatusEnum.EXPIRED);
+            }
+
+            log.info("✅ [{}~{}] 쿠폰 ID={}의 미사용 발급건 {}건 만료 처리 완료",
+                    oneHourAgo, now, coupon.getId(), issues.size());
+        }
+    }
+}

--- a/src/main/java/com/example/fastcoupon/service/CouponUseService.java
+++ b/src/main/java/com/example/fastcoupon/service/CouponUseService.java
@@ -1,0 +1,56 @@
+package com.example.fastcoupon.service;
+
+import com.example.fastcoupon.entity.Coupon;
+import com.example.fastcoupon.entity.CouponIssue;
+import com.example.fastcoupon.enums.CouponStatusEnum;
+import com.example.fastcoupon.enums.ExceptionEnum;
+import com.example.fastcoupon.exception.ErrorException;
+import com.example.fastcoupon.repository.CouponIssueRepository;
+import com.example.fastcoupon.repository.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CouponUseService {
+
+    private final CouponIssueRepository couponIssueRepository;
+    private final CouponRepository couponRepository;
+
+    @Transactional
+    public void useCoupon(Long couponId, Long couponIssueId, Long userId) {
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new ErrorException(ExceptionEnum.COUPON_NOT_FOUND));
+
+        CouponIssue couponIssue = couponIssueRepository.findById(couponIssueId).orElseThrow(
+                () -> new ErrorException(ExceptionEnum.COUPON_NOT_FOUND)
+        );
+
+        if (!couponIssue.getUserId().equals(userId)) {
+            throw new ErrorException(ExceptionEnum.NOT_ALLOW);
+        }
+
+        if (couponIssue.isUsed() || couponIssue.getStatus().equals(CouponStatusEnum.USED)) {
+            throw new ErrorException(ExceptionEnum.COUPON_ALREADY_USED);
+        }
+
+        if (couponIssue.getStatus().equals(CouponStatusEnum.EXPIRED)) {
+            throw new ErrorException(ExceptionEnum.COUPON_EXPIRED);
+        }
+
+        if (coupon.getExpiredAt().isBefore(LocalDateTime.now())) {
+            couponIssue.updateStatus(CouponStatusEnum.EXPIRED);
+            log.info("⛔ 만료된 쿠폰 사용 시도 차단 - couponId={}, userId={}", couponId, userId);
+            throw new ErrorException(ExceptionEnum.COUPON_EXPIRED);
+        }
+
+        couponIssue.updateUsed(true);
+        couponIssue.updateUsedAt(LocalDateTime.now());
+        couponIssue.updateStatus(CouponStatusEnum.USED);
+    }
+}

--- a/src/test/java/com/example/fastcoupon/service/CouponUseServiceTest.java
+++ b/src/test/java/com/example/fastcoupon/service/CouponUseServiceTest.java
@@ -1,0 +1,122 @@
+package com.example.fastcoupon.service;
+
+import com.example.fastcoupon.entity.Coupon;
+import com.example.fastcoupon.entity.CouponIssue;
+import com.example.fastcoupon.enums.CouponStatusEnum;
+import com.example.fastcoupon.enums.CouponTypeEnum;
+import com.example.fastcoupon.exception.ErrorException;
+import com.example.fastcoupon.repository.CouponIssueRepository;
+import com.example.fastcoupon.repository.CouponRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CouponUseServiceTest {
+
+    @Autowired
+    CouponUseService couponUseService;
+
+    @Autowired
+    CouponRepository couponRepository;
+
+    @Autowired
+    CouponIssueRepository couponIssueRepository;
+
+    private Long userId = 123L;
+    private Coupon coupon;
+    private CouponIssue couponIssue;
+
+    @BeforeEach
+    void setup() {
+        coupon = couponRepository.save(
+                Coupon.createCoupon("테스트 쿠폰", CouponTypeEnum.CHICKEN, 10, LocalDateTime.now().plusDays(1))
+        );
+        couponIssue = couponIssueRepository.save(
+                CouponIssue.builder()
+                        .couponId(coupon.getId())
+                        .userId(userId)
+                        .build()
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        couponRepository.deleteAllInBatch();
+        couponIssueRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("정상적인 쿠폰 사용 요청은 성공해야 한다")
+    @Test
+    void useCoupon_성공() {
+        // given
+        Long couponId = coupon.getId();
+        Long couponIssueId = couponIssue.getId();
+
+        // when
+        couponUseService.useCoupon(couponId, couponIssueId, userId);
+
+        // then
+
+        CouponIssue result = couponIssueRepository.findById(couponIssue.getId()).get();
+        assertThat(result.isUsed()).isTrue();
+        assertThat(result.getStatus()).isEqualTo(CouponStatusEnum.USED);
+        assertThat(result.getUsedAt()).isNotNull();
+    }
+
+    @DisplayName("다른 유저가 사용하려고 하면 예외가 발생한다")
+    @Test
+    void useCoupon_다른유저_예외() {
+        // given
+        Long otherUser = 999L;
+
+        // when & then
+        assertThatThrownBy(() ->
+                couponUseService.useCoupon(coupon.getId(), couponIssue.getId(), otherUser)
+        ).isInstanceOf(ErrorException.class);
+    }
+
+    @DisplayName("이미 사용한 쿠폰은 다시 사용할 수 없다")
+    @Test
+    void useCoupon_이미사용된쿠폰_예외() {
+        // given
+        couponIssue.updateStatus(CouponStatusEnum.USED);
+        couponIssue.updateUsed(true);
+        couponIssueRepository.save(couponIssue);
+
+        // when & then
+        assertThatThrownBy(() ->
+                couponUseService.useCoupon(coupon.getId(), couponIssue.getId(), userId)
+        ).isInstanceOf(ErrorException.class);
+    }
+
+    @DisplayName("유효기간이 지난 쿠폰은 사용할 수 없다")
+    @Test
+    void useCoupon_만료된쿠폰_예외() {
+        // given
+        Coupon expiredCoupon = couponRepository.save(
+                Coupon.createCoupon("만료 쿠폰", CouponTypeEnum.CHICKEN, 10, LocalDateTime.now().minusDays(1))
+        );
+        CouponIssue expiredIssue = couponIssueRepository.save(
+                CouponIssue.builder()
+                        .couponId(expiredCoupon.getId())
+                        .userId(userId)
+                        .build()
+        );
+
+        // when & then
+        assertThatThrownBy(() ->
+                couponUseService.useCoupon(expiredCoupon.getId(), expiredIssue.getId(), userId)
+        ).isInstanceOf(ErrorException.class);
+    }
+}


### PR DESCRIPTION
### 💡 주요 변경 사항
- 쿠폰 사용 처리 서비스 로직 구현
- 쿠폰 만료 자동화 스케줄러 도입
  - 만료일시가 경과한 쿠폰의 미사용 이력을 주기적으로 만료 처리
- 만료된 쿠폰 또는 이미 사용된 쿠폰에 대한 예외 처리

### 🧪 테스트
- CouponUseServiceTest 단위 테스트 추가
  - 정상 사용 / 타 유저 사용 시도 / 이미 사용됨 / 만료된 쿠폰 등 예외 케이스 포함